### PR TITLE
Refactor shiny-tracer.js

### DIFF
--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -1,46 +1,44 @@
+window.shinytest = (function() {
+    var shinytest = {
+        connected: false,
+        busy: null,
+        updating: [],
+        log_entries: [],
+        entries_shown: 0
+    };
 
-function shinytest_create_store() {
-    if (!window.shinytest) {
-	window.shinytest = {
-	    connected: true,
-	    busy: null,
-	    updating: [],
-	    log_entries: [],
-	    entries_shown: 0,
-	    log: function(message) {
-		window.shinytest.log_entries.push({
-		    timestamp: new Date().toISOString(),
-		    message: message
-		})
-	    }
-	};
-    }
-}
+    shinytest.log = function(message) {
+        shinytest.log_entries.push({
+            timestamp: new Date().toISOString(),
+            message: message
+        });
+    };
 
-$(document).on("shiny:connected", function(e) {
-    shinytest_create_store();
-    window.shinytest.log("connected");
-});
 
-$(document).on("shiny:busy", function(e) {
-    shinytest_create_store();
-    window.shinytest.busy = true;
-    window.shinytest.log("busy");
-});
+    $(document).on("shiny:connected", function(e) {
+        shinytest.connected = true;
+        shinytest.log("connected");
+    });
 
-$(document).on("shiny:idle", function(e) {
-    shinytest_create_store();
-    window.shinytest.busy = false;
-    window.shinytest.log("idle");
-});
+    $(document).on("shiny:busy", function(e) {
+        shinytest.busy = true;
+        shinytest.log("busy");
+    });
 
-$(document).on("shiny:value", function(e) {
-    shinytest_create_store();
-    window.shinytest.log("value " + e.name);
+    $(document).on("shiny:idle", function(e) {
+        shinytest.busy = false;
+        shinytest.log("idle");
+    });
 
-    // Clear up updates
-    var idx = window.shinytest.updating.indexOf(e.name);
-    if (idx != -1) {
-	window.shinytest.updating.splice(idx, 1);
-    }
-});
+    $(document).on("shiny:value", function(e) {
+        shinytest.log("value " + e.name);
+
+        // Clear up updates
+        var idx = shinytest.updating.indexOf(e.name);
+        if (idx != -1) {
+            shinytest.updating.splice(idx, 1);
+        }
+    });
+
+    return shinytest;
+})();


### PR DESCRIPTION
This PR doesn't change any functionality, but it does set the stage for more complex JS code that I would like to add. The closure lets you simulate private variables and functions -- only the members on the `shinytest` object are "public".

This pattern is used by Vega, and I've used it in other code of mine:
https://github.com/vega/vega/blob/master/src/scene/axis.js

If you don't like it, feel free to let me know. :)

Also, I changed all the tabs to spaces. I hope that's OK. My editor doesn't really like mixing tabs and spaces.