### PR TITLE
Add shinyapp$set_inputs()

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -263,7 +263,16 @@ shinyapp <- R6Class(
     expect_update = function(output, ..., timeout = 3000,
       iotype = c("auto", "input", "output"))
       app_expect_update(self, private, output, ..., timeout = timeout,
-                        iotype = match.arg(iotype))
+                        iotype = match.arg(iotype)),
+
+    set_inputs = function(...)
+      app_set_inputs(self, private, ...),
+
+    queue_inputs = function(...)
+      app_queue_inputs(self, private, ...),
+
+    flush_inputs = function()
+      app_flush_inputs(self, private)
   ),
 
   private = list(

--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -1,0 +1,18 @@
+app_set_inputs <- function(self, private, ...) {
+  app_queue_inputs(self, private, ...)
+  app_flush_inputs(self, private)
+}
+
+app_queue_inputs <- function(self, private, ...) {
+  inputs <- list(...)
+  assert_all_named(inputs)
+
+  private$web$execute_script(
+    "shinytest.inputqueue.add(arguments[0]);",
+    inputs
+  )
+}
+
+app_flush_inputs <- function(self, private) {
+  private$web$execute_script("shinytest.inputqueue.flush();")
+}

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -15,6 +15,38 @@ window.shinytest = (function() {
     };
 
 
+    shinytest.inputqueue = (function() {
+        var inputqueue = {};
+
+        var queue = [];
+
+        // Add a set of inputs to the queue. Format of `inputs` must be
+        // `{ input1: value1, input2: value2 }`.
+        inputqueue.add = function(inputs) {
+            for (var name in inputs) {
+                shinytest.log("inputqueue: pushing " + name + ":" + inputs[name]);
+                queue.push({
+                    name: name,
+                    value: inputs[name]
+                });
+            }
+        };
+
+        inputqueue.flush = function() {
+            queue.map(function(item) {
+                shinytest.log("inputqueue: flushing " + item.name + ":" + item.value);
+                var $el = $("#" + item.name);
+                $el.data("shinyInputBinding").setValue($el[0], item.value);
+                $el.trigger("change");
+            });
+
+            queue = [];
+        };
+
+        return inputqueue;
+    })();
+
+
     $(document).on("shiny:connected", function(e) {
         shinytest.connected = true;
         shinytest.log("connected");


### PR DESCRIPTION
This is an initial attempt at setting inputs in one go. It shifts more of the work into Javascript.

Here's how it can be used:

```R
app <- shinyapp$new("tests/testthat/apps/081-widgets-gallery")
# Using expect_update
expect_update(app, checkbox = FALSE, output = "checkboxOut")
expect_equal(app$get_value("checkboxOut"), "[1] FALSE")

# Using set_inputs
app$set_inputs(checkbox = TRUE, text = "Hello, world!")
expect_equal(app$get_value("checkbox"), TRUE)
expect_equal(app$get_value("text"), "Hello, world!")
```

A few notes:
* It's not possible to set a single value right now, because of the unboxing behavior. 
* Setting the checkbox to FALSE doesn't work yet.
* It doesn't check the type of the input right now -- it just sends names and values to the Javascript side, and then that side sets the values all at once. This means that it'll be faster, because it doesn't need to fetch each widget. But it's also not as robust and doesn't massage the values before passing them to the input binding's `setValue()` method.

In general, I think doing most anything on the R or JS side is pretty fast. What slows things down is the communication between the two sides, so reducing the number of messages going back and forth is important for performance.