### PR TITLE
Fix is_all_named for zero-length vectors

### DIFF
--- a/R/assertions.R
+++ b/R/assertions.R
@@ -34,7 +34,7 @@ on_failure(is_port) <- function(call, env) {
 }
 
 is_all_named <- function(x) {
-  !is.null(names(x)) && all(names(x) != "")
+  length(names(x)) == length(x) && all(names(x) != "")
 }
 
 on_failure(is_all_named) <- function(call, env) {


### PR DESCRIPTION
Here's a set of tests:

```R
library(testthat)
expect_true(is_all_named(NULL))
expect_true(is_all_named(c()))
expect_false(is_all_named(c(1)))
expect_true(is_all_named(c(a=1)))
expect_false(is_all_named(c(a=1, 2)))
expect_false(is_all_named(c(a=1, 2)[2]))  # Vector has name attribute, but all names are ""
```

On master, the first two tests fail. After the fix, all tests pass.

I saw this when I ran into the same issue in webdriver. The current implementation is actually different there! I'll submit a fix there as well.
