### PR TITLE
Change set_inputs() to return output values

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^README.Rmd$
 ^.travis.yml$
 ^appveyor.yml$
+^travis_phantomjs$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,22 @@
 language: r
 sudo: false
-cache: packages
+
+# Use newer version of PhantomJS than is installed by default on basic R image.
+# Code referenced from:
+#   https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-255500144
+cache:
+  packages:
+  directories:
+    - "travis_phantomjs"
+before_install:
+  - "export PHANTOMJS_VERSION=2.1.1"
+  - "phantomjs --version"
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH"
+  - "phantomjs --version"
+  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "phantomjs --version"
 
 r:
  - release
@@ -11,3 +27,4 @@ r_github_packages:
   - gaborcsardi/debugme
   - MangoTheCat/processx
   - MangoTheCat/webdriver
+  - rstudio/shiny

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,5 +23,6 @@ Imports:
     utils,
     webdriver,
     withr
+Remotes: rstudio/shiny
 Encoding: UTF-8
 SystemRequirements: PhantomJS (http://phantomjs.org/)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
     processx,
     R6,
     rematch,
-    shiny,
+    shiny (>= 0.14.1.9001),
     testthat (>= 1.0.0),
     utils,
     webdriver,

--- a/R/app-get-all-values.R
+++ b/R/app-get-all-values.R
@@ -1,0 +1,23 @@
+app_get_all_values <- function(self, private) {
+  "!DEBUG app_get_all_values"
+  res <- private$web$execute_script(
+    "return shinytest.getAllValues();"
+  )
+
+  if (!is.null(res$inputs)) {
+    # Use Shiny's applyInputHandlers function. Note that the R process running
+    # Shiny is not the same as this one, and there are two possible drawbacks to
+    # doing this.
+    #
+    # (1) It's possible for a package to register an input handler in the Shiny
+    # R process that isn't available in this process
+    #
+    # (2) It's hypothetically possible for the version of Shiny that's being
+    # tested to differ from the version of Shiny that's available in this
+    # process, and the input handlers could be different between the versions.
+    # This is very unlikely to happen in actual testing scenarios, though.
+    res$inputs <- shiny::applyInputHandlers(res$inputs)
+  }
+
+  res
+}

--- a/R/app.R
+++ b/R/app.R
@@ -263,8 +263,9 @@ shinyapp <- R6Class(
       app_expect_update(self, private, output, ..., timeout = timeout,
                         iotype = match.arg(iotype)),
 
-    set_inputs = function(...)
-      app_set_inputs(self, private, ...),
+    set_inputs = function(..., wait_ = TRUE, values_ = TRUE, timeout_ = 1000)
+      app_set_inputs(self, private, ..., wait_ = wait_, values_ = values_,
+                     timeout_ = 1000),
 
     expect_outputs = function(...)
       app_expect_outputs(self, private, ...)
@@ -293,8 +294,8 @@ shinyapp <- R6Class(
     queue_inputs = function(...)
       app_queue_inputs(self, private, ...),
 
-    flush_inputs = function()
-      app_flush_inputs(self, private),
+    flush_inputs = function(wait = TRUE, returnValues = TRUE, timeout = 1000)
+      app_flush_inputs(self, private, wait, returnValues, timeout),
 
     get_outputs = function(outputs)
       app_get_outputs(self, private, outputs)

--- a/R/app.R
+++ b/R/app.R
@@ -214,6 +214,9 @@ shinyapp <- R6Class(
     get_debug_log = function(type = c("all", shinyapp$debug_log_types))
       app_get_debug_log(self, private, match.arg(type, several.ok = TRUE)),
 
+    enable_debug_log_messages = function(enable = TRUE)
+      app_enable_debug_log_messages(self, private, enable),
+
     ## These are just forwarded to the webdriver session
 
     get_url = function()

--- a/R/app.R
+++ b/R/app.R
@@ -272,7 +272,7 @@ shinyapp <- R6Class(
       app_expect_update(self, private, output, ..., timeout = timeout,
                         iotype = match.arg(iotype)),
 
-    set_inputs = function(..., wait_ = TRUE, values_ = TRUE, timeout_ = 1000)
+    set_inputs = function(..., wait_ = TRUE, values_ = TRUE, timeout_ = 3000)
       app_set_inputs(self, private, ..., wait_ = wait_, values_ = values_,
                      timeout_ = timeout_)
   ),

--- a/R/app.R
+++ b/R/app.R
@@ -197,6 +197,9 @@ shinyapp <- R6Class(
     set_value = function(name, value, iotype = c("auto", "input", "output"))
       app_set_value(self, private, name, value, match.arg(iotype)),
 
+    get_all_values = function()
+      app_get_all_values(self, private),
+
     send_keys = function(name = NULL, keys)
       app_send_keys(self, private, name, keys),
 
@@ -261,7 +264,10 @@ shinyapp <- R6Class(
                         iotype = match.arg(iotype)),
 
     set_inputs = function(...)
-      app_set_inputs(self, private, ...)
+      app_set_inputs(self, private, ...),
+
+    expect_outputs = function(...)
+      app_expect_outputs(self, private, ...)
   ),
 
   private = list(
@@ -288,7 +294,10 @@ shinyapp <- R6Class(
       app_queue_inputs(self, private, ...),
 
     flush_inputs = function()
-      app_flush_inputs(self, private)
+      app_flush_inputs(self, private),
+
+    get_outputs = function(outputs)
+      app_get_outputs(self, private, outputs)
   )
 )
 
@@ -307,6 +316,13 @@ app_set_value <- function(self, private, name, value, iotype) {
   "!DEBUG app_set_value `name`"
   self$find_widget(name, iotype)$set_value(value)
   invisible(self)
+}
+
+app_get_all_values <- function(self, private) {
+  "!DEBUG app_get_all_values"
+  private$web$execute_script(
+    "return shinytest.getAllValues();"
+  )
 }
 
 app_send_keys <- function(self, private, name, keys) {

--- a/R/app.R
+++ b/R/app.R
@@ -106,6 +106,10 @@
 #' \code{app$set_inputs()} sets the value of inputs. The arguments must all
 #' be named; an input with each name will be assigned the given value.
 #'
+#' \code{app$upload_file()} uploads a file to a file input. The argument must
+#' be named and the value must be the path to a local file; that file will be
+#' uploaded to a file input with that name.
+#'
 #' \code{app$get_all_values()} returns a named list of all inputs, outputs,
 #' and error values.
 #'
@@ -274,7 +278,11 @@ shinyapp <- R6Class(
 
     set_inputs = function(..., wait_ = TRUE, values_ = TRUE, timeout_ = 3000)
       app_set_inputs(self, private, ..., wait_ = wait_, values_ = values_,
-                     timeout_ = timeout_)
+                     timeout_ = timeout_),
+
+    upload_file = function(..., wait_ = TRUE, values_ = TRUE, timeout_ = 3000)
+      app_upload_file(self, private, ..., wait_ = wait_, values_ = values_,
+                      timeout_ = timeout_)
   ),
 
   private = list(

--- a/R/app.R
+++ b/R/app.R
@@ -103,6 +103,12 @@
 #' \code{app$get_value()} finds a widget and queries its value. See
 #' the \code{get_value} method of the \code{\link{widget}} class.
 #'
+#' \code{app$set_inputs()} sets the value of inputs. The arguments must all
+#' be named; an input with each name will be assigned the given value.
+#'
+#' \code{app$get_all_values()} returns a named list of all inputs, outputs,
+#' and error values.
+#'
 #' \code{app$set_value()} finds a widget and sets its value. See the
 #' \code{set_value} method of the \code{\link{widget}} class.
 #'

--- a/R/app.R
+++ b/R/app.R
@@ -268,10 +268,7 @@ shinyapp <- R6Class(
 
     set_inputs = function(..., wait_ = TRUE, values_ = TRUE, timeout_ = 1000)
       app_set_inputs(self, private, ..., wait_ = wait_, values_ = values_,
-                     timeout_ = 1000),
-
-    expect_outputs = function(...)
-      app_expect_outputs(self, private, ...)
+                     timeout_ = 1000)
   ),
 
   private = list(
@@ -298,10 +295,7 @@ shinyapp <- R6Class(
       app_queue_inputs(self, private, ...),
 
     flush_inputs = function(wait = TRUE, returnValues = TRUE, timeout = 1000)
-      app_flush_inputs(self, private, wait, returnValues, timeout),
-
-    get_outputs = function(outputs)
-      app_get_outputs(self, private, outputs)
+      app_flush_inputs(self, private, wait, returnValues, timeout)
   )
 )
 

--- a/R/app.R
+++ b/R/app.R
@@ -322,13 +322,6 @@ app_set_value <- function(self, private, name, value, iotype) {
   invisible(self)
 }
 
-app_get_all_values <- function(self, private) {
-  "!DEBUG app_get_all_values"
-  private$web$execute_script(
-    "return shinytest.getAllValues();"
-  )
-}
-
 app_send_keys <- function(self, private, name, keys) {
   "!DEBUG app_send_keys `name`"
   self$find_widget(name)$send_keys(keys)

--- a/R/app.R
+++ b/R/app.R
@@ -268,7 +268,7 @@ shinyapp <- R6Class(
 
     set_inputs = function(..., wait_ = TRUE, values_ = TRUE, timeout_ = 1000)
       app_set_inputs(self, private, ..., wait_ = wait_, values_ = values_,
-                     timeout_ = 1000)
+                     timeout_ = timeout_)
   ),
 
   private = list(

--- a/R/debugging.R
+++ b/R/debugging.R
@@ -40,6 +40,13 @@ app_get_debug_log <- function(self, private, type) {
   merge_logs(output)
 }
 
+app_enable_debug_log_messages <- function(self, private, enable = TRUE) {
+  private$web$execute_script(
+    "window.shinytest.log_messages = arguments[0]",
+    enable
+  )
+}
+
 make_shiny_console_log <- function(out, err) {
   out <- data.frame(
     stringsAsFactors = FALSE,

--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -1,6 +1,16 @@
-app_set_inputs <- function(self, private, ...) {
+app_set_inputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE) {
   app_queue_inputs(self, private, ...)
   app_flush_inputs(self, private)
+
+  if (values_ && !wait_) {
+    stop("values_=TRUE and wait_=FALSE are not compatible.",
+      "Can't return all values without waiting for update.")
+  }
+
+  if (values_)
+    app_get_all_values(self, private)
+  else
+    invisible()
 }
 
 app_queue_inputs <- function(self, private, ...) {

--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -1,5 +1,5 @@
 app_set_inputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
-                           timeout_ = 1000) {
+                           timeout_ = 3000) {
   if (values_ && !wait_) {
     stop("values_=TRUE and wait_=FALSE are not compatible.",
       "Can't return all values without waiting for update.")

--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -21,7 +21,7 @@ app_queue_inputs <- function(self, private, ...) {
 }
 
 app_flush_inputs <- function(self, private, wait, returnValues, timeout) {
-  private$web$execute_script_async(
+  res <- private$web$execute_script_async(
     "var wait = arguments[0];
     var returnValues = arguments[1];
     var timeout = arguments[2];
@@ -31,4 +31,13 @@ app_flush_inputs <- function(self, private, wait, returnValues, timeout) {
     returnValues,
     timeout
   )
+
+  # Treatmeent of res$inputs here is the same as in app_get_all_values. We don't
+  # call that function to get the values because it involves a separate
+  # execute_script_async call, which may introduce timing problems.
+  if (!is.null(res$inputs)) {
+    res$inputs <- shiny::applyInputHandlers(res$inputs)
+  }
+
+  res
 }

--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -26,15 +26,15 @@ app_flush_inputs <- function(self, private, wait, returnValues, timeout) {
     var returnValues = arguments[1];
     var timeout = arguments[2];
     var callback = arguments[3];
-    shinytest.outputWaiter.start(timeout);
+    shinytest.outputValuesWaiter.start(timeout);
     shinytest.inputQueue.flush();
-    shinytest.outputWaiter.finish(wait, returnValues, callback);",
+    shinytest.outputValuesWaiter.finish(wait, returnValues, callback);",
     wait,
     returnValues,
     timeout
   )
 
-  # Treatmeent of res$inputs here is the same as in app_get_all_values. We don't
+  # Treatment of res$inputs here is the same as in app_get_all_values. We don't
   # call that function to get the values because it involves a separate
   # execute_script_async call, which may introduce timing problems.
   if (!is.null(res$inputs)) {
@@ -58,7 +58,7 @@ app_upload_file <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
 
   private$web$execute_script(
     "var timeout = arguments[0];
-    shinytest.outputWaiter.start(timeout);",
+    shinytest.outputValuesWaiter.start(timeout);",
     timeout_
   )
 
@@ -68,12 +68,12 @@ app_upload_file <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
     "var wait = arguments[0];
     var returnValues = arguments[1];
     var callback = arguments[2];
-    shinytest.outputWaiter.finish(wait, returnValues, callback);",
+    shinytest.outputValuesWaiter.finish(wait, returnValues, callback);",
     wait_,
     values_
   )
 
-  # Treatmeent of res$inputs here is the same as in app_get_all_values. We don't
+  # Treatment of res$inputs here is the same as in app_get_all_values. We don't
   # call that function to get the values because it involves a separate
   # execute_script_async call, which may introduce timing problems.
   if (!is.null(res$inputs)) {

--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -26,7 +26,9 @@ app_flush_inputs <- function(self, private, wait, returnValues, timeout) {
     var returnValues = arguments[1];
     var timeout = arguments[2];
     var callback = arguments[3];
-    shinytest.inputQueue.flushAndReturnValuesAsync(wait, returnValues, timeout, callback);",
+    shinytest.outputWaiter.start(timeout);
+    shinytest.inputQueue.flush();
+    shinytest.outputWaiter.finish(wait, returnValues, callback);",
     wait,
     returnValues,
     timeout
@@ -40,4 +42,44 @@ app_flush_inputs <- function(self, private, wait, returnValues, timeout) {
   }
 
   res
+}
+
+app_upload_file <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
+                            timeout_ = 3000) {
+  if (values_ && !wait_) {
+    stop("values_=TRUE and wait_=FALSE are not compatible.",
+      "Can't return all values without waiting for update.")
+  }
+
+  inputs <- list(...)
+  if (length(inputs) != 1 || !is_all_named(inputs)) {
+    stop("Can only upload file to exactly one input, and input must be named")
+  }
+
+  private$web$execute_script(
+    "var timeout = arguments[0];
+    shinytest.outputWaiter.start(timeout);",
+    timeout_
+  )
+
+  self$find_widget(names(inputs)[1])$upload_file(inputs[[1]])
+
+  res <- private$web$execute_script_async(
+    "var wait = arguments[0];
+    var returnValues = arguments[1];
+    var callback = arguments[2];
+    shinytest.outputWaiter.finish(wait, returnValues, callback);",
+    wait_,
+    values_
+  )
+
+  # Treatmeent of res$inputs here is the same as in app_get_all_values. We don't
+  # call that function to get the values because it involves a separate
+  # execute_script_async call, which may introduce timing problems.
+  if (!is.null(res$inputs)) {
+    res$inputs <- shiny::applyInputHandlers(res$inputs)
+  }
+
+  res
+
 }

--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -26,7 +26,7 @@ app_flush_inputs <- function(self, private, wait, returnValues, timeout) {
     var returnValues = arguments[1];
     var timeout = arguments[2];
     var callback = arguments[3];
-    shinytest.inputQueue.flushAndWaitAsync(wait, returnValues, timeout, callback);",
+    shinytest.inputQueue.flushAndReturnValuesAsync(wait, returnValues, timeout, callback);",
     wait,
     returnValues,
     timeout

--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -1,16 +1,13 @@
-app_set_inputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE) {
-  app_queue_inputs(self, private, ...)
-  app_flush_inputs(self, private)
-
+app_set_inputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
+                           timeout_ = 1000) {
   if (values_ && !wait_) {
     stop("values_=TRUE and wait_=FALSE are not compatible.",
       "Can't return all values without waiting for update.")
   }
 
-  if (values_)
-    app_get_all_values(self, private)
-  else
-    invisible()
+  private$queue_inputs(...)
+  vals <- private$flush_inputs(wait_, values_, timeout_)
+  return(vals)
 }
 
 app_queue_inputs <- function(self, private, ...) {
@@ -23,6 +20,15 @@ app_queue_inputs <- function(self, private, ...) {
   )
 }
 
-app_flush_inputs <- function(self, private) {
-  private$web$execute_script("shinytest.inputQueue.flush();")
+app_flush_inputs <- function(self, private, wait, returnValues, timeout) {
+  private$web$execute_script_async(
+    "var wait = arguments[0];
+    var returnValues = arguments[1];
+    var timeout = arguments[2];
+    var callback = arguments[3];
+    shinytest.inputQueue.flushAndWaitAsync(wait, returnValues, timeout, callback);",
+    wait,
+    returnValues,
+    timeout
+  )
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ build_script:
   - travis-tool.sh install_github gaborcsardi/debugme
   - travis-tool.sh install_github MangoTheCat/processx
   - travis-tool.sh install_github MangoTheCat/webdriver
+  - travis-tool.sh install_github rstudio/shiny
 
 test_script:
   - travis-tool.sh run_tests

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -167,52 +167,52 @@ window.shinytest = (function() {
             }
         }
 
+
+        // This waits for a shiny:message event to occur, where the messsage
+        // contains a field named `values`. That is a message from the server with
+        // output values. When that occurs, invoke the callback. Or, if timeout
+        // elapses without seeing such a message, invoke the callback.
+        function waitForOutputValues(timeout, callback) {
+            if (timeout === undefined) timeout = 3000;
+
+            // This is a bit of a hack: we want the callback to be invoked _after_
+            // the outputs are assigned. Because the shiny:message event is
+            // triggered just before the output values are assigned, we need to
+            // wait for the next tick of the eventloop.
+            var callbackWrapper = function() {
+                setTimeout(callback, 0);
+            };
+
+            // Check that a message contains `values` field.
+            function checkMessage(e) {
+                if (e.message && e.message.values) {
+                    shinytest.log("Found message with values field.");
+
+                    $(document).off("shiny:message", checkMessage);
+                    clearTimeout(timeoutCallback);
+
+                    callbackWrapper();
+                }
+            }
+
+            $(document).on("shiny:message", checkMessage);
+
+            // If timeout elapses without finding message, remove listener and
+            // invoke callback.
+            var timeoutCallback = setTimeout(function() {
+                shinytest.log("Timed out without finding message with values field.");
+
+                $(document).off("shiny:message", checkMessage);
+
+                callbackWrapper();
+            }, timeout);
+        }
+
         return {
             start: start,
             finish: finish
         };
     })();
-
-
-    // This waits for a shiny:message event to occur, where the messsage
-    // contains a field named `values`. That is a message from the server with
-    // output values. When that occurs, invoke the callback. Or, if timeout
-    // elapses without seeing such a message, invoke the callback.
-    var waitForOutputValues = function(timeout, callback) {
-        if (timeout === undefined) timeout = 3000;
-
-        // This is a bit of a hack: we want the callback to be invoked _after_
-        // the outputs are assigned. Because the shiny:message event is
-        // triggered just before the output values are assigned, we need to
-        // wait for the next tick of the eventloop.
-        var callbackWrapper = function() {
-            setTimeout(callback, 0);
-        };
-
-        // Check that a message contains `values` field.
-        function checkMessage(e) {
-            if (e.message && e.message.values) {
-                shinytest.log("Found message with values field.");
-
-                $(document).off("shiny:message", checkMessage);
-                clearTimeout(timeoutCallback);
-
-                callbackWrapper();
-            }
-        }
-
-        $(document).on("shiny:message", checkMessage);
-
-        // If timeout elapses without finding message, remove listener and
-        // invoke callback.
-        var timeoutCallback = setTimeout(function() {
-            shinytest.log("Timed out without finding message with values field.");
-
-            $(document).off("shiny:message", checkMessage);
-
-            callbackWrapper();
-        }, timeout);
-    };
 
 
     shinytest.listWidgets = function() {

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -34,15 +34,33 @@ window.shinytest = (function() {
         };
 
         inputqueue.flush = function() {
-            queue.map(function(item) {
+
+            function flushItem(item) {
                 shinytest.log("inputQueue: flushing " + item.name);
                 var $el = $("#" + item.name);
+                var msg;
+
+                if ($el.length === 0) {
+                    msg = "Unable to find element with id " + item.name;
+                    shinytest.log("  " + msg);
+                    throw msg;
+                }
+                if ($el.data("shinyInputBinding") === undefined) {
+                    msg = "Unable to find input binding for element with id " + item.name;
+                    shinytest.log("  " + msg);
+                    throw msg;
+                }
+
                 $el.data("shinyInputBinding").setValue($el[0], item.value);
                 $el.trigger("change");
-            });
+            }
 
-            queue = [];
-        }
+            try {
+                queue.map(flushItem);
+            } finally {
+                queue = [];
+            }
+        };
 
         // Async wrapper for flush(). If wait==true, then wait for a message
         // coming back from server before invoking callback. If

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -84,7 +84,7 @@ window.shinytest = (function() {
 
             if (!wait) {
                 if (returnValues)
-                    throw "Can't return values without waiting."
+                    throw "Can't return values without waiting.";
                 else
                     callback();
             }
@@ -132,7 +132,7 @@ window.shinytest = (function() {
 
             callbackWrapper();
         }, timeout);
-    }
+    };
 
 
     shinytest.listWidgets = function() {
@@ -147,7 +147,7 @@ window.shinytest = (function() {
 	    return getids(els)
 		.map(function(x) {
 		    var id = '#' + x + ',' + '#' + x;
-		    return getids($(id))
+		    return getids($(id));
 		});
 	}
 

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -99,7 +99,7 @@ window.shinytest = (function() {
             },
 
             "shiny.actionButtonInput": function(el, value) {
-                if (!(value === "click")) {
+                if (value !== "click") {
                     throw 'The only valid value for an actionButton is "click".';
                 }
 

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -99,7 +99,7 @@ window.shinytest = (function() {
         function findInputBinding(el) {
             var $el = $(el);
             if ($el.length === 0 || !$el.data("shinyInputBinding")) {
-                var msg = "Unable to find input binding for ID " + id;
+                var msg = "Unable to find input binding for element";
                 shinytest.log("  " + msg);
                 throw msg;
             }

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -67,6 +67,14 @@ window.shinytest = (function() {
 		 'output': get('.shiny-bound-output') };
     };
 
+    // Returns values from input or output bindings
+    shinytest.getAllValues = function(ids) {
+        return {
+            inputs: Shiny.shinyapp.$inputValues,
+            outputs: Shiny.shinyapp.$values,
+            errors: Shiny.shinyapp.$errors
+        };
+    };
 
     $(document).on("shiny:connected", function(e) {
         shinytest.connected = true;

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -142,7 +142,7 @@ window.shinytest = (function() {
     // output values. When that occurs, invoke the callback. Or, if timeout
     // elapses without seeing such a message, invoke the callback.
     var waitForOutputValues = function(timeout, callback) {
-        if (timeout === undefined) timeout = 1000;
+        if (timeout === undefined) timeout = 3000;
 
         // This is a bit of a hack: we want the callback to be invoked _after_
         // the outputs are assigned. Because the shiny:message event is

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -115,20 +115,21 @@ window.shinytest = (function() {
 
     // Async wrapper object. Should be invoked like this:
     //
-    // shinytest.outputWaiter.start(timeout);
+    // shinytest.outputValuesWaiter.start(timeout);
     // someFunction();
-    // shinytest.outputWaiter.finish(wait, returnValues, callback);",
+    // shinytest.outputValuesWaiter.finish(wait, returnValues, callback);
     //
     // Where `someFunction` is a function that does the desired work. The
     // reason that the callback function must be passed to the `finish()`
     // instead of `start()` is because calling `execute_script_async()` from
-    // the remote machine converts it into a synchronous call.
+    // the R side is synchronous; it returns only when `callback()` is
+    // invoked.
     //
     // If wait==true, then wait for a message from server containing output
     // values before invoking callback. If returnValues==true, pass all input,
     // output, and error values to the callback. If `timeout` ms elapses
     // without a message arriving, invoke the callback.
-    shinytest.outputWaiter = (function() {
+    shinytest.outputValuesWaiter = (function() {
         var found = false;
         var finishCallback = null;
 

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -105,6 +105,10 @@ window.shinytest = (function() {
 
                 // Instead of setting a value, we'll just trigger a click.
                 $(el).trigger("click");
+            },
+
+            "shiny.fileInputBinding": function(el, value) {
+                throw "Setting value of fileInput is not supported.";
             }
         };
 

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -4,7 +4,8 @@ window.shinytest = (function() {
         busy: null,
         updating: [],
         log_entries: [],
-        entries_shown: 0
+        entries_shown: 0,
+        log_messages: false
     };
 
     shinytest.log = function(message) {
@@ -158,6 +159,11 @@ window.shinytest = (function() {
     $(document).on("shiny:idle", function(e) {
         shinytest.busy = false;
         shinytest.log("idle");
+    });
+
+    $(document).on("shiny:message", function(e) {
+        if (shinytest.log_messages)
+            shinytest.log("message: " + JSON.stringify(e.message));
     });
 
     $(document).on("shiny:value", function(e) {

--- a/man/shinyapp.Rd
+++ b/man/shinyapp.Rd
@@ -113,6 +113,12 @@ the app, and also the phantomjs instance.
 \code{app$get_value()} finds a widget and queries its value. See
 the \code{get_value} method of the \code{\link{widget}} class.
 
+\code{app$set_inputs()} sets the value of inputs. The arguments must all
+be named; an input with each name will be assigned the given value.
+
+\code{app$get_all_values()} returns a named list of all inputs, outputs,
+and error values.
+
 \code{app$set_value()} finds a widget and sets its value. See the
 \code{set_value} method of the \code{\link{widget}} class.
 

--- a/man/shinyapp.Rd
+++ b/man/shinyapp.Rd
@@ -116,6 +116,10 @@ the \code{get_value} method of the \code{\link{widget}} class.
 \code{app$set_inputs()} sets the value of inputs. The arguments must all
 be named; an input with each name will be assigned the given value.
 
+\code{app$upload_file()} uploads a file to a file input. The argument must
+be named and the value must be the path to a local file; that file will be
+uploaded to a file input with that name.
+
 \code{app$get_all_values()} returns a named list of all inputs, outputs,
 and error values.
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -3,6 +3,6 @@ library(shinytest)
 
 if (Sys.getenv("NOT_CRAN", "") != "" || Sys.getenv("CI", "") != "") {
   if (is.null(shinytest:::find_phantom())) webdriver::install_phantomjs()
-  message("Using phantom.js from", shinytest:::find_phantom(), "\n")
+  message("Using phantom.js from ", shinytest:::find_phantom(), "\n")
   test_check("shinytest")
 }

--- a/tests/testthat/test-app-set-inputs.R
+++ b/tests/testthat/test-app-set-inputs.R
@@ -1,0 +1,54 @@
+context("app$set_inputs")
+
+
+test_that("app$set_inputs for all input widgets", {
+  app <- shinyapp$new(test_path("apps/081-widgets-gallery"))
+
+  # Check initial values
+  x <- app$get_all_values()
+  expect_identical(x$inputs$checkbox, TRUE)
+  expect_identical(x$inputs$checkGroup, "1")
+  expect_identical(x$inputs$date, as.Date("2014-01-01"))
+  expect_identical(x$inputs$dates, rep(Sys.Date(), 2))
+  expect_identical(x$inputs$num, 1L)
+  expect_identical(x$inputs$radio, "1")
+  expect_identical(x$inputs$select, "1")
+  expect_identical(x$inputs$slider1, 50L)
+  expect_identical(x$inputs$slider2, c(25L, 75L))
+  expect_identical(x$inputs$text, "Enter text...")
+
+  # Set inputs
+  x <- app$set_inputs(
+    checkbox = FALSE,
+    checkGroup = c("2", "3"),
+    date = as.Date("2016-01-01"),
+    dates = c("2016-01-01", "2016-12-31"),
+    num = 42,
+    radio = "2",
+    select = "2",
+    slider1 = 80,
+    slider2 = c(10, 90),
+    text = "Hello"
+  )
+
+  expect_identical(x$inputs$checkbox, FALSE)
+  expect_identical(x$outputs$checkboxOut, "[1] FALSE")
+  expect_identical(x$inputs$checkGroup, c("2", "3"))
+  expect_identical(x$outputs$checkGroupOut, '[1] "2" "3"')
+  expect_identical(x$inputs$date, as.Date("2016-01-01"))
+  expect_identical(x$outputs$dateOut, '[1] "2016-01-01"')
+  expect_identical(x$inputs$dates, as.Date(c("2016-01-01", "2016-12-31")))
+  expect_identical(x$outputs$datesOut, '[1] "2016-01-01" "2016-12-31"')
+  expect_identical(x$inputs$num, 42L)
+  expect_identical(x$outputs$numOut, "[1] 42")
+  expect_identical(x$inputs$radio, "2")
+  expect_identical(x$outputs$radioOut, '[1] "2"')
+  expect_identical(x$inputs$select, "2")
+  expect_identical(x$outputs$selectOut, '[1] "2"')
+  expect_identical(x$inputs$slider1, 80L)
+  expect_identical(x$outputs$slider1Out, "[1] 80")
+  expect_identical(x$inputs$slider2, c(10L, 90L))
+  expect_identical(x$outputs$slider2Out, "[1] 10 90")
+  expect_identical(x$inputs$text, "Hello")
+  expect_identical(x$outputs$textOut, '[1] "Hello"')
+})

--- a/tests/testthat/test-app-set-inputs.R
+++ b/tests/testthat/test-app-set-inputs.R
@@ -6,6 +6,10 @@ test_that("app$set_inputs for all input widgets", {
 
   # Check initial values
   x <- app$get_all_values()
+  expect_identical(
+    x$inputs$action,
+    structure(0L, class = c("integer", "shinyActionButtonValue"))
+  )
   expect_identical(x$inputs$checkbox, TRUE)
   expect_identical(x$inputs$checkGroup, "1")
   expect_identical(x$inputs$date, as.Date("2014-01-01"))
@@ -19,6 +23,7 @@ test_that("app$set_inputs for all input widgets", {
 
   # Set inputs
   x <- app$set_inputs(
+    action = "click",
     checkbox = FALSE,
     checkGroup = c("2", "3"),
     date = as.Date("2016-01-01"),
@@ -31,6 +36,14 @@ test_that("app$set_inputs for all input widgets", {
     text = "Hello"
   )
 
+  expect_identical(
+    x$inputs$action,
+    structure(1L, class = c("integer", "shinyActionButtonValue"))
+  )
+  expect_identical(
+    '[1] 1\nattr(,"class")\n[1] "integer"                "shinyActionButtonValue"',
+    x$outputs$actionOut
+  )
   expect_identical(x$inputs$checkbox, FALSE)
   expect_identical(x$outputs$checkboxOut, "[1] FALSE")
   expect_identical(x$inputs$checkGroup, c("2", "3"))

--- a/tests/testthat/test-app-set-inputs.R
+++ b/tests/testthat/test-app-set-inputs.R
@@ -1,9 +1,8 @@
 context("app$set_inputs")
 
+app <- shinyapp$new(test_path("apps/081-widgets-gallery"))
 
 test_that("app$set_inputs for all input widgets", {
-  app <- shinyapp$new(test_path("apps/081-widgets-gallery"))
-
   # Check initial values
   x <- app$get_all_values()
   expect_identical(
@@ -64,4 +63,10 @@ test_that("app$set_inputs for all input widgets", {
   expect_identical(x$outputs$slider2Out, "[1] 10 90")
   expect_identical(x$inputs$text, "Hello")
   expect_identical(x$outputs$textOut, '[1] "Hello"')
+})
+
+
+test_that("app$upload_file for file inputs", {
+  x <- app$upload_file(file = test_path("apps/081-widgets-gallery/DESCRIPTION"))
+  expect_true(grepl("DESCRIPTION", x$outputs$fileOut))
 })


### PR DESCRIPTION
This is a WIP. It modifies `app$set_inputs()` so that it returns all input, output, and error values. (Error values are any outputs which have errored on the server.)

This makes it possible to do things like:

```R
app <- shinyapp$new("tests/testthat/apps/081-widgets-gallery")
res <- app$set_inputs(checkbox = FALSE, text = "Hello, world!")
expect_identical(res$outputs$checkboxOut, "[1] FALSE")
expect_identical(res$outputs$textOut, "[1] \"Hello, world!\"")
```

Some details: The default behavior is for the client to send values to the server, then wait for the server to send back a response with new output values, and only then fetch all the values. The waiting is event-driven, instead of polled, so it should be fast. If the server doesn't send back a response before a specified timeout (default is 1000ms), then it will return at that time.

Fetching all the values takes a little time (~10ms with the widgets app). In some cases, the user may want to script a sequence of actions without looking at values, and fetching the values will take more time if there are large objects like plots. It's possible to make `set_inputs()` not fetch the values, with `values_=FALSE`.

Inputs are processed with `shiny::applyInputHandlers`. This function is not yet available in shiny's master branch, but is is PR rstudio/shiny#1421.
