### PR TITLE
Add widget$upload_file()

### DIFF
--- a/R/widget.R
+++ b/R/widget.R
@@ -108,7 +108,10 @@ widget <- R6Class(
       widget_send_keys(self, private, keys),
 
     list_tabs = function()
-      widget_list_tabs(self, private)
+      widget_list_tabs(self, private),
+
+    upload_file = function(filename)
+      widget_upload_file(self, private, filename)
 
   ),
 
@@ -139,4 +142,10 @@ widget_list_tabs <- function(self, private) {
   }
   tabs <- private$element$find_elements("li a")
   vapply(tabs, function(t) t$get_data("value"), "")
+}
+
+widget_upload_file <- function(self, private, filename) {
+  private$element$upload_file(
+    filename = filename
+  )
 }


### PR DESCRIPTION
This goes with MangoTheCat/webdriver#44.

The interface makes it feel like the method is being called on the element, but really what happens is that the request is made on the session, with the widget's DOM ID as the CSS selector.

This works now:

```R
app <- shinyapp$new("tests/testthat/apps/081-widgets-gallery")

app$find_widget("file")$upload_file("DESCRIPTION")
Sys.sleep(0.5)
app$get_value("fileOut")
```

I used an ugly hack to get the `session` object to make the request. @gaborcsardi, can you think of a better way to do this?
